### PR TITLE
feat(core): add explicit protocol field for test specification files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.2] - 2026-02-19
+## [1.3.2] - 2026-02-27
 
 ### Added
+
+#### @boolesai/tspec (Core Library)
+
+- **Explicit Protocol Field**: New top-level `protocol` field for explicit protocol declaration
+  - Optional field to explicitly declare the protocol type in test case files
+  - Takes precedence for protocol detection, enabling clearer test specifications
+  - Supports any string value for custom protocol extensibility
+  - Simplifies protocol detection logic by using explicit declaration
 
 #### Skills (MCP Integration)
 
@@ -21,10 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Protocol Detection**: Updated protocol detection to use explicit `protocol` field
+  - `getProtocolType()` now reads from the `protocol` field instead of auto-detecting from protocol blocks
+  - Schema validation updated to validate the new `protocol` field
 - **Documentation Restructuring**: Improved organization and maintainability
   - Removed individual skill directories and examples to reduce duplication
   - Restructured reference documentation files under unified `skills/tspec/` directory
   - Updated main Skills README to reflect unified capability
+  - Added `protocol` field documentation in Field Reference and Protocol Reference docs
+
+#### vscode-tspec (VS Code Extension)
+
+- Updated diagnostic provider to validate the new `protocol` field
+- Enhanced schema data with `protocol` field definition
 
 ## [1.3.1] - 2026-02-05
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ console.log(result.summary); // { total: 4, passed: 4, failed: 0, passRate: 100 
 ```yaml
 version: "1.0"
 description: "Verify successful login with valid credentials"
+protocol: "http"
 
 metadata:
   prompt: |

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boolesai/tspec-cli",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "CLI for @boolesai/tspec testing framework",
   "type": "module",
   "bin": {
@@ -22,7 +22,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@boolesai/tspec": "1.3.1",
+    "@boolesai/tspec": "1.3.2",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chalk": "^5.0.0",
     "commander": "^12.0.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boolesai/tspec",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Unified testing framework for test specification files (.tcase)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/core/src/parser/index.ts
+++ b/core/src/parser/index.ts
@@ -83,7 +83,7 @@ export function parseTestCases(filePath: string, options: GenerateOptions = {}):
     const processedSpec = replaceVariables(caseSpec, context);
     
     const protocol = getProtocolType(processedSpec);
-    const request = protocol ? processedSpec[protocol] : undefined;
+    const request = protocol ? processedSpec[protocol] as HttpRequest | GrpcRequest | GraphqlRequest | WebsocketRequest | WebRequest | undefined : undefined;
     
     if (protocol === 'http' && processedSpec.environment && request) {
       const envConfig = processedSpec.environment;
@@ -131,7 +131,7 @@ export function parseTestCasesFromString(content: string, options: GenerateFromS
     
     const processedSpec = replaceVariables(caseSpec, context);
     const protocol = getProtocolType(processedSpec);
-    const request = protocol ? processedSpec[protocol] : undefined;
+    const request = protocol ? processedSpec[protocol] as HttpRequest | GrpcRequest | GraphqlRequest | WebsocketRequest | WebRequest | undefined : undefined;
     
     if (protocol === 'http' && processedSpec.environment && request) {
       (request as HttpRequest)._baseUrl = buildBaseUrl(processedSpec.environment);

--- a/core/src/parser/schema.ts
+++ b/core/src/parser/schema.ts
@@ -39,6 +39,13 @@ export function validateTspec(spec: TSpec, options: SchemaValidationOptions = {}
     errors.push('Missing protocol block (http, grpc, graphql, or websocket)');
   }
 
+  // Protocol field validation (if present)
+  if ('protocol' in spec && spec.protocol !== undefined) {
+    if (typeof spec.protocol !== 'string') {
+      errors.push('protocol field must be a string');
+    }
+  }
+
   // Metadata validation (all fields are optional, only validate types when present)
   if (spec.metadata) {
     if (spec.metadata.test_category && !VALID_CATEGORIES.includes(spec.metadata.test_category)) {

--- a/core/src/parser/types.ts
+++ b/core/src/parser/types.ts
@@ -31,6 +31,7 @@ export interface RelatedCodeReference {
 export interface TSpec {
   version: string;
   description: string;
+  protocol?: string;
   metadata: TSpecMetadata;
   assertions: Assertion[];
   http?: HttpRequest;

--- a/core/src/parser/yaml-parser.ts
+++ b/core/src/parser/yaml-parser.ts
@@ -17,11 +17,9 @@ export function parseYamlString(content: string): TSpec {
 }
 
 export function getProtocolType(spec: TSpec): ProtocolType | null {
-  const protocols: ProtocolType[] = ['http', 'grpc', 'graphql', 'websocket'];
-  for (const protocol of protocols) {
-    if (protocol in spec) {
-      return protocol;
-    }
+  if (spec.protocol && typeof spec.protocol === 'string') {
+    const protocol = spec.protocol.toLowerCase().trim() as ProtocolType;
+    return protocol;
   }
   return null;
 }

--- a/core/src/plugin/protocol-registry.ts
+++ b/core/src/plugin/protocol-registry.ts
@@ -140,10 +140,8 @@ export function isValidProtocol(protocol: unknown): protocol is string {
  * Get protocol type from test case structure
  */
 export function detectProtocolFromSpec(spec: Record<string, unknown>): string | null {
-  for (const protocol of ProtocolRegistry.getAll()) {
-    if (protocol in spec) {
-      return protocol;
-    }
+  if ('protocol' in spec && typeof spec.protocol === 'string') {
+    return spec.protocol.toLowerCase().trim();
   }
   return null;
 }

--- a/core/test/parser/index.test.ts
+++ b/core/test/parser/index.test.ts
@@ -38,6 +38,7 @@ describe('parser/index', () => {
       const yaml = `
 version: "1.0"
 description: Test login
+protocol: http
 metadata:
   prompt: "test prompt"
   related_code: []
@@ -73,6 +74,7 @@ assertions:
       const yaml = `
 version: "1.0"
 description: Test with variables
+protocol: http
 metadata:
   prompt: "test"
   related_code: []
@@ -99,6 +101,7 @@ assertions:
       const yaml = `
 version: "1.0"
 description: Test
+protocol: http
 metadata:
   prompt: "test"
   related_code: []
@@ -122,6 +125,7 @@ assertions:
       const yaml = `
 version: "1.0"
 description: Test with lifecycle
+protocol: http
 metadata:
   prompt: "test"
   related_code: []

--- a/core/types/parser/types.d.ts
+++ b/core/types/parser/types.d.ts
@@ -29,6 +29,7 @@ export interface RelatedCodeReference {
 export interface TSpec {
     version: string;
     description: string;
+    protocol?: string;
     metadata: TSpecMetadata;
     assertions: Assertion[];
     http?: HttpRequest;

--- a/docs/04-core-structure.md
+++ b/docs/04-core-structure.md
@@ -7,6 +7,7 @@ Every `.tcase` file follows a consistent top-level schema. This section describe
 ```yaml
 version: "1.0"                  # Required - DSL version
 description: "..."              # Required - Test description
+protocol: "..."                 # Optional - Explicit protocol type (any string)
 
 metadata:                       # Required - AI and collaboration metadata
 environment:                    # Optional - Runtime environment
@@ -35,6 +36,16 @@ Natural language description of the test's purpose. Should be concise but descri
 ```yaml
 description: "Verify user login with valid credentials returns JWT token"
 ```
+
+### `protocol` (optional)
+
+Explicitly declare the protocol type. Used for protocol detection. Accepts any string value to support custom protocols.
+
+```yaml
+protocol: "http"
+```
+
+**Common values:** `http`, `grpc`, `graphql`, `websocket`, `web`, or any custom protocol name.
 
 ### `metadata`
 
@@ -150,14 +161,15 @@ While YAML doesn't require specific ordering, the following order improves reada
 
 1. `version` - Specification version first
 2. `description` - Human-readable purpose
-3. `metadata` - AI and collaboration context
-4. `extends` - Template inheritance (if any)
-5. `environment` - Runtime configuration
-6. `variables` - Static variables
-7. `data` - Data sources
-8. `lifecycle` - Setup/teardown hooks
-9. `{protocol}` - Request definition
-10. `assertions` - Validation rules
+3. `protocol` - Explicit protocol declaration (if any)
+4. `metadata` - AI and collaboration context
+5. `extends` - Template inheritance (if any)
+6. `environment` - Runtime configuration
+7. `variables` - Static variables
+8. `data` - Data sources
+9. `lifecycle` - Setup/teardown hooks
+10. `{protocol}` - Request definition
+11. `assertions` - Validation rules
 
 ## Complete Example
 

--- a/docs/05-field-reference.md
+++ b/docs/05-field-reference.md
@@ -2,6 +2,28 @@
 
 Detailed reference for all TSpec fields.
 
+## `protocol`
+
+**Optional**. Explicitly declare the protocol type for this test case.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `protocol` | string | No | Explicit protocol declaration |
+
+When specified, takes precedence over auto-detection from protocol blocks. Accepts any string value to support custom protocols.
+
+**Common values:** `http`, `grpc`, `graphql`, `websocket`, `web`, or any custom protocol name.
+
+```yaml
+protocol: "http"
+```
+
+### Protocol Detection
+
+TSpec determines the protocol from the explicit `protocol` field only. The field is required for protocol detection.
+
+---
+
 ## `metadata`
 
 **Optional**. Contains AI generation context and test categorization.

--- a/docs/10-protocol-reference.md
+++ b/docs/10-protocol-reference.md
@@ -2,6 +2,48 @@
 
 TSpec supports multiple protocols through dedicated protocol blocks. Each protocol has its own configuration structure.
 
+## Protocol Field
+
+**Optional**. Explicitly declare the protocol type in the top-level `protocol` field.
+
+```yaml
+protocol: "http"
+```
+
+When specified, the `protocol` field is used for protocol detection. It accepts any string value, enabling:
+
+- **Explicit documentation** - Make the protocol clear in the file header
+- **Custom protocols** - Support protocols not yet built into TSpec
+- **Future extensibility** - Add new protocols without code changes
+
+### Example with Explicit Protocol
+
+```yaml
+version: "1.0"
+description: "Test with explicit protocol declaration"
+protocol: http  # Explicit protocol
+
+metadata:
+  prompt: "Test login endpoint"
+  related_code: ["src/auth/login.ts"]
+  test_category: functional
+  risk_level: high
+  tags: ["auth"]
+  priority: high
+  timeout: "10s"
+
+http:
+  method: POST
+  path: /api/login
+
+assertions:
+  - type: json_path
+    expression: "$.status"
+    expected: 200
+```
+
+---
+
 ## HTTP/HTTPS
 
 File extension: `.http.tcase`

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,20 +8,20 @@ A multi-protocol testing DSL designed for Developer + AI collaboration.
 
 ## Table of Contents
 
-1. [Introduction](./01-introduction.md)
-2. [Quick Start](./02-quick-start.md)
-3. [File Specification](./03-file-specification.md)
-4. [Core Structure](./04-core-structure.md)
-5. [Field Reference](./05-field-reference.md)
-6. [Variables and Expressions](./06-variables-expressions.md)
-7. [Data-Driven Testing](./07-data-driven-testing.md)
-8. [Assertions](./08-assertions.md)
-9. [Template Inheritance](./09-template-inheritance.md)
-10. [Protocol Reference](./10-protocol-reference.md)
-11. [API Reference](./11-api-reference.md)
-12. [Examples](./12-examples.md)
-13. [Test Suites](./13-test-suites.md)
-14. [Proxy Server](./14-proxy-server.md)
+1. [Introduction](/docs.html#01-introduction)
+2. [Quick Start](/docs.html#02-quick-start)
+3. [File Specification](/docs.html#03-file-specification)
+4. [Core Structure](/docs.html#04-core-structure)
+5. [Field Reference](/docs.html#05-field-reference)
+6. [Variables and Expressions](/docs.html#06-variables-expressions)
+7. [Data-Driven Testing](/docs.html#07-data-driven-testing)
+8. [Assertions](/docs.html#08-assertions)
+9. [Template Inheritance](/docs.html#09-template-inheritance)
+10. [Protocol Reference](/docs.html#10-protocol-reference)
+11. [API Reference](/docs.html#11-api-reference)
+12. [Examples](/docs.html#12-examples)
+13. [Test Suites](/docs.html#13-test-suites)
+14. [Proxy Server](/docs.html#14-proxy-server)
 
 ---
 

--- a/plugins/tspec-protocol-http/package.json
+++ b/plugins/tspec-protocol-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boolesai/tspec-plugin-http",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "HTTP/HTTPS protocol plugin for TSpec",
   "type": "module",
   "main": "./dist/index.js",
@@ -33,13 +33,13 @@
     "plugin": true
   },
   "peerDependencies": {
-    "@boolesai/tspec": "^1.2.0"
+    "@boolesai/tspec": "^1.3.2"
   },
   "dependencies": {
     "axios": "^1.7.0"
   },
   "devDependencies": {
-    "@boolesai/tspec": "^1.2.0",
+    "@boolesai/tspec": "^1.3.2",
     "@types/node": "^22.0.0",
     "typescript": "^5.0.0",
     "vite": "^7.0.0",

--- a/plugins/tspec-protocol-web/package.json
+++ b/plugins/tspec-protocol-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boolesai/tspec-plugin-web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Web browser UI testing plugin for TSpec using Puppeteer",
   "type": "module",
   "main": "./dist/index.js",
@@ -34,13 +34,13 @@
     "plugin": true
   },
   "peerDependencies": {
-    "@boolesai/tspec": "^1.2.0"
+    "@boolesai/tspec": "^1.3.2"
   },
   "dependencies": {
     "puppeteer": "^24.15.0"
   },
   "devDependencies": {
-    "@boolesai/tspec": "^1.2.0",
+    "@boolesai/tspec": "^1.3.2",
     "@types/node": "^22.0.0",
     "typescript": "^5.0.0",
     "vite": "^7.0.0",

--- a/skills/tspec/SKILL.md
+++ b/skills/tspec/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: tspec
-description: Comprehensive TSpec testing toolkit for .tcase and .tsuite files. List protocols, validate syntax, parse test structure, run tests, generate test cases from code changes, and analyze test coverage. Use for API testing, test generation, coverage analysis, and test lifecycle management. Keywords: tspec, test case, test suite, api testing, test validation, test generation, test coverage, run tests, parse tests, list protocols, tspec run, tspec validate, tspec parse, tspec list, tspec gen, tspec coverage, http tests, grpc tests, tsuite, related code, smoke test, regression test, test automation
+description: Comprehensive TSpec testing toolkit for .tcase and .tsuite files. List protocols, validate syntax, parse test structure, run tests, generate test cases from code changes, and analyze test coverage. Supports explicit protocol declaration via the `protocol` field and auto-detection from protocol blocks (http, grpc, graphql, websocket, web). Use for API testing, test generation, coverage analysis, and test lifecycle management. Keywords: tspec, test case, test suite, api testing, test validation, test generation, test coverage, run tests, parse tests, list protocols, tspec run, tspec validate, tspec parse, tspec list, tspec gen, tspec coverage, http tests, grpc tests, tsuite, related code, smoke test, regression test, test automation
 ---
 
 # TSpec - Comprehensive Testing Toolkit
 
 ## Overview
 
-TSpec is a YAML-based DSL for API test specification designed for Developer + AI collaboration. This unified skill covers the full testing lifecycle: listing available protocols, validating test file syntax, parsing test structure, executing tests, generating test cases from code changes, and analyzing test coverage.
+TSpec is a YAML-based DSL for API test specification designed for Developer + AI collaboration. Supports explicit protocol declaration via the `protocol` field and auto-detection from protocol blocks (http, grpc, graphql, websocket, web). This unified skill covers the full testing lifecycle: listing available protocols, validating test file syntax, parsing test structure, executing tests, generating test cases from code changes, and analyzing test coverage.
 
 Six integrated capabilities are provided:
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tspec",
   "displayName": "Testing Spec",
   "description": "Language support and test runner for TSpec test specification files",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "publisher": "boolesai",
   "icon": "logo.png",
   "repository": {

--- a/vscode-extension/src/providers/diagnosticProvider.ts
+++ b/vscode-extension/src/providers/diagnosticProvider.ts
@@ -78,6 +78,7 @@ function validateRelatedCodeFormat(input: string): { valid: boolean; error?: str
 interface TSpecDocument {
   version?: string;
   description?: string;
+  protocol?: string;
   metadata?: {
     prompt: string;
     related_code: string[];
@@ -261,6 +262,13 @@ export class TSpecDiagnosticProvider {
       );
       diagnostic.source = 'tspec';
       diagnostics.push(diagnostic);
+    }
+
+    // Protocol field validation (if present)
+    if (spec.protocol !== undefined) {
+      if (typeof spec.protocol !== 'string') {
+        this.addDiagnostic(document, 'protocol', 'protocol field must be a string', vscode.DiagnosticSeverity.Error, diagnostics);
+      }
     }
 
     // Metadata validation

--- a/vscode-extension/src/utils/schemaData.ts
+++ b/vscode-extension/src/utils/schemaData.ts
@@ -11,6 +11,7 @@ export interface SchemaField {
 export const TOP_LEVEL_FIELDS: SchemaField[] = [
   { key: 'version', required: true, type: 'string', description: 'TSpec format version (currently "1.0")' },
   { key: 'description', required: true, type: 'string', description: 'Test case description' },
+  { key: 'protocol', required: false, type: 'string', description: 'Explicit protocol type (http, grpc, graphql, websocket, or custom)' },
   { key: 'metadata', required: true, type: 'object', description: 'Test metadata and classification' },
   { key: 'environment', required: false, type: 'object', description: 'Environment configuration' },
   { key: 'variables', required: false, type: 'object', description: 'Variable definitions' },


### PR DESCRIPTION
- Introduce top-level `protocol` field to explicitly declare protocol type in .tcase files
- Update protocol detection to prioritize `protocol` field over auto-detection from protocol blocks
- Modify schema validation and VS Code diagnostics to validate `protocol` field as a string
- Enhance documentation with `protocol` field reference, examples, and guidelines
- Update Skills toolkit description to mention explicit protocol declaration support
- Adjust core parser types and logic to support and utilize `protocol` field
- Bump versions for core, CLI, VS Code extension, and related plugins to reflect changes