### PR TITLE
feat(proxy): add DSL-level proxy_server configuration for test and su…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-03-15
+
+### Added
+
+#### @boolesai/tspec (Core Library)
+
+- **DSL-Level Proxy Configuration**: New `proxy_server` field for test case and suite level proxy override
+  - Override proxy settings directly in `.tcase` and `.tsuite` files
+  - Full `ProxyConfig` support: `url`, `timeout`, `headers`, `enabled`, `operations`
+  - Case-level/suite-level settings take precedence over global configuration
+  - Ability to disable proxy for specific tests with `enabled: false`
+  - Schema validation for proxy configuration fields
+
+#### vscode-tspec (VS Code Extension)
+
+- **Proxy Server Field Support**:
+  - Auto-completion for `proxy_server` field and nested properties
+  - Syntax highlighting for proxy configuration keys
+  - IntelliSense support for `url`, `timeout`, `headers`, `enabled`, `operations` fields
+
+#### Skills (MCP Integration)
+
+- **New Command Documentation**:
+  - `tspec plugin:list` - List installed plugins with health status
+  - `tspec plugin:install` - Install plugins from npm or local packages
+  - `tspec mcp` - Start MCP server for AI tool integration
+- Updated skill documentation with 9 integrated capabilities
+
+### Changed
+
+- **Proxy Configuration Hierarchy**: Updated precedence order for proxy settings
+  1. DSL-level config (`proxy_server` in `.tcase` or `.tsuite`) - highest priority
+  2. CLI flags (`--proxy-url`, `--no-proxy`)
+  3. Local config file (`./tspec.config.json`)
+  4. Global config file (`~/.tspec/tspec.config.json`)
+
+### Fixed
+
+- **Documentation**: Added missing Part 14 (Proxy Server) navigation link in `docs.html` sidebar
+- **CLI Documentation**: Added `--no-auto-install` flag to `tspec run` command documentation
+
+### Documentation
+
+- **Field Reference**: Added `proxy_server` field documentation with examples
+- **Proxy Server Guide**: Added DSL-Level Configuration section with precedence rules
+- **Skills Documentation**: 
+  - Created `tspec-plugin-list.md` reference
+  - Created `tspec-plugin-install.md` reference  
+  - Created `tspec-mcp.md` reference
+  - Updated `SKILL.md` with new commands and proxy configuration
+
 ## [1.3.2] - 2026-02-27
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boolesai/tspec-cli",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "CLI for @boolesai/tspec testing framework",
   "type": "module",
   "bin": {
@@ -22,7 +22,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@boolesai/tspec": "1.3.2",
+    "@boolesai/tspec": "1.4.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chalk": "^5.0.0",
     "commander": "^12.0.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boolesai/tspec",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Unified testing framework for test specification files (.tcase)",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/core/src/parser/index.ts
+++ b/core/src/parser/index.ts
@@ -14,6 +14,7 @@ import type {
   ExecutionConfig, RetryConfig, SuiteLifecycleConfig, SuiteLifecycleAction,
   SuiteResult, SuiteTestResult, HookResult, SuiteStats, SuiteAssertionResult
 } from './types.js';
+import type { ProxyConfig } from '../plugin/config.js';
 import type { VariableContext } from './variables.js';
 import type { DataFormat, DataRow, ParameterizedSpec } from './data-driver.js';
 
@@ -27,6 +28,7 @@ export interface TestCase {
   lifecycle?: TSpec['lifecycle'];
   environment?: EnvironmentConfig;
   variables?: Record<string, unknown>;
+  proxy_server?: ProxyConfig;
   _dataRow?: DataRow;
   _raw: TSpec;
 }
@@ -103,6 +105,7 @@ export function parseTestCases(filePath: string, options: GenerateOptions = {}):
       lifecycle: processedSpec.lifecycle,
       environment: processedSpec.environment,
       variables: processedSpec.variables,
+      proxy_server: processedSpec.proxy_server,
       _dataRow: caseSpec._dataRow,
       _raw: processedSpec
     };
@@ -150,6 +153,7 @@ export function parseTestCasesFromString(content: string, options: GenerateFromS
       lifecycle: processedSpec.lifecycle,
       environment: processedSpec.environment,
       variables: processedSpec.variables,
+      proxy_server: processedSpec.proxy_server,
       _dataRow: caseSpec._dataRow,
       _raw: processedSpec
     };
@@ -246,6 +250,8 @@ export interface ParsedSuite {
   
   execution?: ExecutionConfig;
   depends_on?: string[];
+  
+  proxy_server?: ProxyConfig;
   
   tests: ResolvedTestReference[];
   nestedSuites: ParsedSuite[];
@@ -367,6 +373,9 @@ export function applySuiteTemplateInheritance(suite: TSpecSuite, baseDir: string
           ) as unknown as ExecutionConfig
         : undefined,
       
+      // Proxy server: suite takes precedence over template
+      proxy_server: suite.suite.proxy_server ?? resolvedTemplate.suite.proxy_server,
+      
       // depends_on from suite only (not inherited)
       depends_on: suite.suite.depends_on,
       
@@ -423,5 +432,6 @@ export type {
   ExecutionConfig, RetryConfig, SuiteLifecycleConfig, SuiteLifecycleAction,
   SuiteResult, SuiteTestResult, HookResult, SuiteStats, SuiteAssertionResult
 } from './types.js';
+export type { ProxyConfig } from '../plugin/config.js';
 export type { VariableContext } from './variables.js';
 export type { DataFormat, DataRow, ParameterizedSpec } from './data-driver.js';

--- a/core/src/parser/schema.ts
+++ b/core/src/parser/schema.ts
@@ -10,15 +10,78 @@ import type {
   SuiteMetadata,
   SuiteLifecycleAction
 } from './types.js';
+import type { ProxyConfig } from '../plugin/config.js';
 import { validateRelatedCodeFormat } from './related-code.js';
 
 const VALID_CATEGORIES = ['functional', 'integration', 'performance', 'security'] as const;
 const VALID_RISK_LEVELS = ['low', 'medium', 'high', 'critical'] as const;
 const VALID_PRIORITIES = ['low', 'medium', 'high'] as const;
 const PROTOCOL_BLOCKS: ProtocolType[] = ['http', 'grpc', 'graphql', 'websocket'];
+const VALID_PROXY_OPERATIONS = ['run', 'validate', 'parse'] as const;
 
 export interface SchemaValidationOptions {
   strict?: boolean;
+}
+
+/**
+ * Validates proxy_server configuration
+ */
+function validateProxyConfig(proxy: ProxyConfig, path: string, errors: string[]): void {
+  // url validation
+  if (proxy.url !== undefined) {
+    if (typeof proxy.url !== 'string' || proxy.url.trim() === '') {
+      errors.push(`${path}.url must be a non-empty string`);
+    } else {
+      // Basic URL format validation
+      try {
+        const url = new URL(proxy.url);
+        if (!['http:', 'https:'].includes(url.protocol)) {
+          errors.push(`${path}.url must use http or https protocol`);
+        }
+      } catch {
+        errors.push(`${path}.url must be a valid URL`);
+      }
+    }
+  }
+
+  // timeout validation
+  if (proxy.timeout !== undefined) {
+    if (typeof proxy.timeout !== 'number' || proxy.timeout <= 0) {
+      errors.push(`${path}.timeout must be a positive number`);
+    }
+  }
+
+  // headers validation
+  if (proxy.headers !== undefined) {
+    if (typeof proxy.headers !== 'object' || proxy.headers === null) {
+      errors.push(`${path}.headers must be an object`);
+    } else {
+      for (const [key, value] of Object.entries(proxy.headers)) {
+        if (typeof value !== 'string') {
+          errors.push(`${path}.headers.${key} must be a string`);
+        }
+      }
+    }
+  }
+
+  // enabled validation
+  if (proxy.enabled !== undefined && typeof proxy.enabled !== 'boolean') {
+    errors.push(`${path}.enabled must be a boolean`);
+  }
+
+  // operations validation
+  if (proxy.operations !== undefined) {
+    if (!Array.isArray(proxy.operations)) {
+      errors.push(`${path}.operations must be an array`);
+    } else {
+      for (const op of proxy.operations) {
+        if (!VALID_PROXY_OPERATIONS.includes(op as typeof VALID_PROXY_OPERATIONS[number])) {
+          errors.push(`${path}.operations must contain only: ${VALID_PROXY_OPERATIONS.join(', ')}`);
+          break;
+        }
+      }
+    }
+  }
 }
 
 export function validateTspec(spec: TSpec, options: SchemaValidationOptions = {}): ValidationResult {
@@ -144,6 +207,11 @@ export function validateTspec(spec: TSpec, options: SchemaValidationOptions = {}
         errors.push(`data.format must be one of: ${validFormats.join(', ')}`);
       }
     }
+  }
+
+  // Proxy server validation
+  if (spec.proxy_server) {
+    validateProxyConfig(spec.proxy_server, 'proxy_server', errors);
   }
 
   return {
@@ -495,6 +563,11 @@ function validateSuiteDefinition(suite: SuiteDefinition, errors: string[]): void
         validateSuiteReference(ref, index, errors);
       });
     }
+  }
+
+  // Proxy server validation
+  if (suite.proxy_server) {
+    validateProxyConfig(suite.proxy_server, 'suite.proxy_server', errors);
   }
 
   // Warn if no tests or suites defined

--- a/core/src/parser/types.ts
+++ b/core/src/parser/types.ts
@@ -1,3 +1,5 @@
+import type { ProxyConfig } from '../plugin/config.js';
+
 /**
  * Represents a line range in a source file.
  * For single lines, start equals end.
@@ -44,6 +46,7 @@ export interface TSpec {
   environment?: EnvironmentConfig;
   data?: DataConfig;
   lifecycle?: LifecycleConfig;
+  proxy_server?: ProxyConfig;
 }
 
 export interface TSpecMetadata {
@@ -502,22 +505,24 @@ export interface SuiteDefinition {
   name: string;                    // Required: Suite name
   description?: string;            // Human-readable description
   version?: string;                // Suite version (default: "1.0")
-  
+
   extends?: string;                // Template inheritance
   depends_on?: string[];           // Suite dependencies (file paths)
-  
+
   metadata?: SuiteMetadata;        // AI and categorization metadata
   environment?: EnvironmentConfig; // Shared environment settings
   variables?: Record<string, unknown>; // Suite-level variables
-  
+
   lifecycle?: SuiteLifecycleConfig; // Suite-level setup/teardown
   before_each?: SuiteLifecycleAction[]; // Per-test setup (beforeEach)
   after_each?: SuiteLifecycleAction[];  // Per-test teardown (afterEach)
-  
+
   execution?: ExecutionConfig;     // Execution control
-  
+
   tests?: TestReference[];         // Test file references (file or files glob)
   suites?: SuiteReference[];       // Nested suite references
+
+  proxy_server?: ProxyConfig;      // Override proxy server configuration
 }
 
 /**

--- a/docs/05-field-reference.md
+++ b/docs/05-field-reference.md
@@ -434,3 +434,76 @@ lifecycle:
         console.log("Cleaning up test user: " + test_user_id);
         return {};
 ```
+
+---
+
+## `proxy_server`
+
+**Optional**. Override proxy server configuration for this test case or suite.
+
+When specified, these settings take precedence over global proxy configuration defined in `tspec.config.json`. This allows routing specific tests through different proxy servers or disabling proxy for certain tests.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `url` | string | Yes* | - | Proxy server URL (http or https) |
+| `timeout` | number | No | 30000 | Request timeout in milliseconds |
+| `headers` | object | No | {} | Custom HTTP headers (supports `${ENV_VAR}` expansion) |
+| `enabled` | boolean | No | true | Enable/disable proxy |
+| `operations` | array | No | ["run", "validate", "parse"] | Operations to proxy |
+
+*Required if `proxy_server` is specified and `enabled` is not `false`.
+
+### Configuration Hierarchy
+
+When both global config and DSL-level config exist:
+
+1. DSL-level `url` overrides global `url`
+2. DSL-level `timeout` overrides global `timeout`
+3. DSL-level `headers` are merged with global headers (DSL takes precedence for same keys)
+4. DSL-level `enabled` overrides global `enabled`
+5. DSL-level `operations` overrides global `operations`
+
+### Example: Override Proxy URL
+
+```yaml
+version: "1.0"
+description: "Test using different proxy"
+proxy_server:
+  url: "https://special-proxy.example.com"
+  timeout: 60000
+  headers:
+    Authorization: "Bearer ${TSPEC_PROXY_TOKEN}"
+  operations: ["run"]
+```
+
+### Example: Disable Proxy for Specific Test
+
+```yaml
+version: "1.0"
+description: "Test that bypasses proxy"
+proxy_server:
+  enabled: false
+```
+
+### Suite-Level Proxy
+
+You can also specify `proxy_server` at the suite level to apply to all tests in that suite:
+
+```yaml
+suite:
+  name: "API Test Suite"
+  proxy_server:
+    url: "https://suite-proxy.example.com"
+    timeout: 120000
+  tests:
+    - file: "tests/test1.http.tcase"
+    - file: "tests/test2.http.tcase"
+```
+
+### Precedence Order
+
+1. **Test case `proxy_server`** (highest priority)
+2. **Suite `proxy_server`**
+3. **Global config** (`tspec.config.json`)
+
+See [Proxy Server](./14-proxy-server.md) for complete proxy configuration documentation.

--- a/docs/14-proxy-server.md
+++ b/docs/14-proxy-server.md
@@ -55,11 +55,12 @@ Add the `proxy` section to your `tspec.config.json`:
 
 ### Configuration Hierarchy
 
-1. **Global Config** (`~/.tspec/tspec.config.json`) - Organization-wide settings
-2. **Local Config** (`./tspec.config.json`) - Project-specific overrides
-3. **CLI Flags** - One-time overrides
+1. **DSL-level Config** (`proxy_server` in `.tcase` or `.tsuite`) - Highest priority
+2. **Global Config** (`~/.tspec/tspec.config.json`) - Organization-wide settings
+3. **Local Config** (`./tspec.config.json`) - Project-specific overrides
+4. **CLI Flags** - One-time overrides
 
-Local config takes precedence over global. CLI flags take precedence over both.
+DSL-level config takes precedence over all others. CLI flags take precedence over config files.
 
 ### Environment Variables in Headers
 
@@ -120,6 +121,132 @@ tspec parse tests/*.tcase --no-proxy
 |------|-------------|
 | `--proxy-url <url>` | Override configured proxy URL |
 | `--no-proxy` | Disable proxy for this execution |
+
+## DSL-Level Configuration
+
+You can override proxy settings directly in `.tcase` or `.tsuite` files using the `proxy_server` field. This allows:
+
+- Routing specific tests through different proxy servers
+- Disabling proxy for certain tests
+- Per-suite proxy configuration
+
+### Test Case Level
+
+Override proxy for individual test cases:
+
+```yaml
+# tests/special-proxy.http.tcase
+version: "1.0"
+description: "Test using different proxy"
+
+proxy_server:
+  url: "https://special-proxy.example.com"
+  timeout: 120000
+  headers:
+    Authorization: "Bearer ${SPECIAL_PROXY_TOKEN}"
+  operations: ["run"]
+
+metadata:
+  prompt: "Test with custom proxy"
+  test_category: "functional"
+  risk_level: "high"
+
+http:
+  method: "GET"
+  path: "/api/internal"
+
+assertions:
+  - type: "json_path"
+    expression: "$.status"
+    expected: 200
+```
+
+### Suite Level
+
+Apply proxy settings to all tests in a suite:
+
+```yaml
+# suites/api.http.tsuite
+suite:
+  name: "API Test Suite"
+  description: "Tests routed through suite proxy"
+  
+  proxy_server:
+    url: "https://suite-proxy.example.com"
+    timeout: 60000
+  
+  tests:
+    - file: "tests/test1.http.tcase"
+    - file: "tests/test2.http.tcase"
+```
+
+### Disabling Proxy
+
+Disable proxy for specific tests that should run locally:
+
+```yaml
+version: "1.0"
+description: "Test that bypasses proxy"
+
+proxy_server:
+  enabled: false
+
+metadata:
+  prompt: "Local test without proxy"
+  test_category: "functional"
+  risk_level: "medium"
+
+http:
+  method: "GET"
+  path: "/api/health"
+
+assertions:
+  - type: "json_path"
+    expression: "$.status"
+    expected: 200
+```
+
+### Merge Behavior
+
+When DSL-level and global configs both exist:
+
+| Field | Behavior |
+|-------|----------|
+| `url` | DSL overrides global |
+| `timeout` | DSL overrides global |
+| `headers` | Merged (DSL takes precedence for same keys) |
+| `enabled` | DSL overrides global |
+| `operations` | DSL overrides global |
+
+**Example - Merged Headers:**
+
+Global config:
+```json
+{
+  "proxy": {
+    "url": "https://proxy.example.com",
+    "headers": {
+      "Authorization": "Bearer global-token",
+      "X-Team": "engineering"
+    }
+  }
+}
+```
+
+DSL config:
+```yaml
+proxy_server:
+  headers:
+    Authorization: "Bearer dsl-token"
+    X-Request-ID: "12345"
+```
+
+Effective headers:
+```yaml
+Authorization: "Bearer dsl-token"  # DSL overrides
+X-Team: "engineering"               # From global
+X-Request-ID: "12345"              # From DSL
+```
 
 ## API Specification
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -404,6 +404,7 @@
         <a href="#11-api-reference" class="nav-item" data-file="11-api-reference.md">11. API Reference</a>
         <a href="#12-examples" class="nav-item" data-file="12-examples.md">12. Examples</a>
         <a href="#13-test-suites" class="nav-item" data-file="13-test-suites.md">13. Test Suites</a>
+        <a href="#14-proxy-server" class="nav-item" data-file="14-proxy-server.md">14. Proxy Server</a>
       </nav>
     </aside>
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,11 +6,11 @@ This directory contains the unified TSpec skill that provides comprehensive capa
 
 | Skill | Description |
 |-------|-------------|
-| [tspec](./tspec/SKILL.md) | Comprehensive TSpec toolkit: list protocols, validate syntax, parse tests, run tests, generate test cases, and analyze coverage |
+| [tspec](./tspec/SKILL.md) | Comprehensive TSpec toolkit: list protocols, validate syntax, parse tests, run tests, generate test cases, analyze coverage, manage plugins, and MCP server |
 
 ## Capabilities
 
-The **tspec** skill provides six integrated capabilities:
+The **tspec** skill provides nine integrated capabilities:
 
 ### 1. List Protocols (tspec list)
 
@@ -75,6 +75,35 @@ Analyze TSpec test coverage based on `metadata.related_code`. Use this to:
 - Track coverage trends over time
 - Prioritize test creation efforts
 
+### 7. List Plugins (tspec plugin:list)
+
+List installed TSpec plugins and their status. Use this to:
+- View installed plugins and versions
+- Check plugin health status
+- Verify plugin installation
+
+**CLI Command:** `tspec plugin:list` (alias: `tspec plugins`)
+
+### 8. Install Plugins (tspec plugin:install)
+
+Install TSpec plugins from npm or local packages. Use this to:
+- Install plugins from npm registry
+- Install local plugin packages
+- Manage plugin installation globally or locally
+
+**CLI Command:** `tspec plugin:install` (alias: `tspec install`)
+
+### 9. MCP Server (tspec mcp)
+
+Start the Model Context Protocol (MCP) server for AI tool integration. Use this to:
+- Expose TSpec capabilities to AI assistants
+- Enable programmatic test execution
+- Integrate with Claude Desktop and other MCP clients
+
+**CLI Command:** `tspec mcp`
+
+**Available MCP Tools:** `tspec_list`, `tspec_validate`, `tspec_parse`, `tspec_run`
+
 ## Typical Workflow
 
 ```
@@ -134,7 +163,10 @@ skills/
     │   ├── tspec-parse.md
     │   ├── tspec-run.md
     │   ├── tspec-gen.md
-    │   └── tspec-coverage.md
+    │   ├── tspec-coverage.md
+    │   ├── tspec-plugin-list.md
+    │   ├── tspec-plugin-install.md
+    │   └── tspec-mcp.md
     └── examples/
         └── example.md           # Comprehensive examples
 ```

--- a/skills/tspec/SKILL.md
+++ b/skills/tspec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tspec
-description: Comprehensive TSpec testing toolkit for .tcase and .tsuite files. List protocols, validate syntax, parse test structure, run tests, generate test cases from code changes, and analyze test coverage. Supports explicit protocol declaration via the `protocol` field and auto-detection from protocol blocks (http, grpc, graphql, websocket, web). Use for API testing, test generation, coverage analysis, and test lifecycle management. Keywords: tspec, test case, test suite, api testing, test validation, test generation, test coverage, run tests, parse tests, list protocols, tspec run, tspec validate, tspec parse, tspec list, tspec gen, tspec coverage, http tests, grpc tests, tsuite, related code, smoke test, regression test, test automation
+description: Comprehensive TSpec testing toolkit for .tcase and .tsuite files. List protocols, validate syntax, parse test structure, run tests, generate test cases from code changes, and analyze test coverage. Supports explicit protocol declaration via the `protocol` field and auto-detection from protocol blocks (http, grpc, graphql, websocket, web). Use for API testing, test generation, coverage analysis, and test lifecycle management. Keywords: tspec, test case, test suite, api testing, test validation, test generation, test coverage, run tests, parse tests, list protocols, tspec run, tspec validate, tspec parse, tspec list, tspec gen, tspec coverage, http tests, grpc tests, tsuite, related code, smoke test, regression test, test automation, mcp, plugin
 ---
 
 # TSpec - Comprehensive Testing Toolkit
@@ -9,7 +9,7 @@ description: Comprehensive TSpec testing toolkit for .tcase and .tsuite files. L
 
 TSpec is a YAML-based DSL for API test specification designed for Developer + AI collaboration. Supports explicit protocol declaration via the `protocol` field and auto-detection from protocol blocks (http, grpc, graphql, websocket, web). This unified skill covers the full testing lifecycle: listing available protocols, validating test file syntax, parsing test structure, executing tests, generating test cases from code changes, and analyzing test coverage.
 
-Six integrated capabilities are provided:
+Nine integrated capabilities are provided:
 
 | # | Capability | MCP Tool | Reference |
 |---|-----------|----------|-----------|
@@ -19,6 +19,9 @@ Six integrated capabilities are provided:
 | 4 | Run Tests | `tspec_run` | [tspec-run](reference/tspec-run.md) |
 | 5 | Generate Test Cases | - | [tspec-gen](reference/tspec-gen.md) |
 | 6 | Analyze Test Coverage | - | [tspec-coverage](reference/tspec-coverage.md) |
+| 7 | List Plugins | - | [tspec-plugin-list](reference/tspec-plugin-list.md) |
+| 8 | Install Plugins | - | [tspec-plugin-install](reference/tspec-plugin-install.md) |
+| 9 | MCP Server | - | [tspec-mcp](reference/tspec-mcp.md) |
 
 ## Typical Workflow
 
@@ -119,6 +122,48 @@ Analyze test coverage by examining `metadata.related_code` across `.tcase` files
 
 ---
 
+## 7. List Plugins (tspec plugin:list)
+
+List installed TSpec plugins and their status. Plugins extend TSpec with custom protocols, assertions, and lifecycle actions. See [full reference](reference/tspec-plugin-list.md).
+
+**No MCP tool** - CLI command.
+
+```bash
+tspec plugin:list
+tspec plugins          # alias
+tspec plugin:list --health
+```
+
+---
+
+## 8. Install Plugins (tspec plugin:install)
+
+Install TSpec plugins from npm or local packages. See [full reference](reference/tspec-plugin-install.md).
+
+**No MCP tool** - CLI command.
+
+```bash
+tspec plugin:install @tspec/plugin-custom
+tspec install @tspec/plugin-custom    # alias
+tspec plugin:install ./local-plugin --global
+```
+
+---
+
+## 9. MCP Server (tspec mcp)
+
+Start the Model Context Protocol (MCP) server for AI tool integration. Exposes TSpec capabilities to AI assistants like Claude. See [full reference](reference/tspec-mcp.md).
+
+**No MCP tool** - this IS the MCP server command.
+
+```bash
+tspec mcp              # Start MCP server
+```
+
+**Available MCP Tools:** `tspec_list`, `tspec_validate`, `tspec_parse`, `tspec_run`
+
+---
+
 ## Proxy Execution
 
 All execution capabilities (run, validate, parse) support remote proxy execution. Configure proxy in `tspec.config.json`:
@@ -144,6 +189,32 @@ tspec run tests/*.tcase --proxy-url http://localhost:8080
 # Disable proxy
 tspec run tests/*.tcase --no-proxy
 ```
+
+### DSL-Level Proxy Configuration
+
+Override proxy settings directly in `.tcase` or `.tsuite` files:
+
+```yaml
+# .tcase file
+proxy_server:
+  url: "https://special-proxy.example.com"
+  timeout: 60000
+  headers:
+    Authorization: "Bearer ${TSPEC_PROXY_TOKEN}"
+  operations: ["run"]
+```
+
+```yaml
+# .tsuite file
+suite:
+  name: "API Test Suite"
+  proxy_server:
+    url: "https://suite-proxy.example.com"
+  tests:
+    - file: "tests/test1.http.tcase"
+```
+
+**Precedence order:** Test case > Suite > CLI flags > Config file
 
 When proxy is configured, operations are automatically forwarded to the remote server. The output includes a `[Proxy: <url>]` indicator.
 

--- a/skills/tspec/reference/tspec-mcp.md
+++ b/skills/tspec/reference/tspec-mcp.md
@@ -1,0 +1,164 @@
+# tspec mcp
+
+Start the Model Context Protocol (MCP) server for AI tool integration. This command exposes TSpec capabilities as tools that can be used by AI assistants like Claude Desktop.
+
+## CLI Command
+
+### Usage
+
+```bash
+tspec mcp
+```
+
+The MCP server runs as a long-running process that communicates via stdio. It is typically started automatically by MCP clients like Claude Desktop.
+
+## Available MCP Tools
+
+When the MCP server is running, the following tools are available:
+
+| Tool | Description |
+|------|-------------|
+| `tspec_list` | List supported protocols and configuration |
+| `tspec_validate` | Validate test file syntax |
+| `tspec_parse` | Parse and inspect test files |
+| `tspec_run` | Execute tests and return results |
+
+## Claude Desktop Configuration
+
+To use TSpec with Claude Desktop, add the following to your Claude Desktop configuration:
+
+### macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+### Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "tspec": {
+      "command": "npx",
+      "args": ["-y", "@boolesai/tspec-cli", "mcp"],
+      "env": {}
+    }
+  }
+}
+```
+
+### With Local Installation
+
+If TSpec is installed locally in your project:
+
+```json
+{
+  "mcpServers": {
+    "tspec": {
+      "command": "node",
+      "args": ["./node_modules/@boolesai/tspec-cli/dist/index.js", "mcp"],
+      "cwd": "/path/to/your/project",
+      "env": {}
+    }
+  }
+}
+```
+
+## Using MCP Tools
+
+Once configured, you can ask Claude to use TSpec tools:
+
+**Example prompts for Claude:**
+
+```
+List the available TSpec protocols
+```
+
+```
+Validate all test files in the tests/ directory
+```
+
+```
+Run the API test suite and show me the results
+```
+
+```
+Parse the login.http.tcase file and show me its structure
+```
+
+## Tool Parameters
+
+### tspec_list
+
+```json
+{
+  "output": "json"
+}
+```
+
+### tspec_validate
+
+```json
+{
+  "files": ["tests/*.http.tcase"],
+  "output": "json"
+}
+```
+
+### tspec_parse
+
+```json
+{
+  "files": ["tests/login.http.tcase"],
+  "env": { "API_HOST": "localhost" },
+  "params": {},
+  "verbose": false,
+  "output": "json"
+}
+```
+
+### tspec_run
+
+```json
+{
+  "files": ["tests/*.http.tcase"],
+  "concurrency": 5,
+  "env": { "API_HOST": "localhost:3000" },
+  "params": {},
+  "failFast": false,
+  "output": "json"
+}
+```
+
+## Server Lifecycle
+
+1. MCP client (Claude Desktop) starts the TSpec MCP server
+2. Server registers tools with the client
+3. Client can invoke tools as needed
+4. Server processes requests and returns results
+5. Server runs until the client terminates it
+
+## Troubleshooting
+
+### Server Not Starting
+
+Check the Claude Desktop logs:
+- macOS: `~/Library/Logs/Claude/`
+- Windows: `%APPDATA%\Claude\Logs\`
+
+### Tool Not Found
+
+Ensure TSpec CLI is properly installed:
+
+```bash
+npx @boolesai/tspec-cli list
+```
+
+### Connection Errors
+
+1. Verify the path to the TSpec CLI is correct
+2. Check that Node.js is installed and accessible
+3. Ensure environment variables are set correctly
+
+## Related Documentation
+
+- [tspec list](./tspec-list.md) - List protocols tool reference
+- [tspec validate](./tspec-validate.md) - Validate tool reference
+- [tspec parse](./tspec-parse.md) - Parse tool reference
+- [tspec run](./tspec-run.md) - Run tool reference

--- a/skills/tspec/reference/tspec-plugin-install.md
+++ b/skills/tspec/reference/tspec-plugin-install.md
@@ -1,0 +1,132 @@
+# tspec plugin:install
+
+Install a TSpec plugin from npm or a local package and add it to your configuration.
+
+## CLI Command
+
+### Usage
+
+```bash
+tspec plugin:install <plugin> [options]
+tspec install <plugin> [options]    # alias
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<plugin>` | Plugin name (npm package name, e.g., `@tspec/http`) |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `json`, `text` (default: `text`) |
+| `-g, --global` | Add plugin to global config (`~/.tspec/tspec.config.json`) |
+| `-c, --config <path>` | Path to specific config file to update |
+
+### CLI Examples
+
+```bash
+# Install a plugin from npm
+tspec plugin:install @tspec/http
+
+# Use the alias
+tspec install @tspec/http
+
+# Install to global config
+tspec plugin:install @tspec/http --global
+
+# Install to specific config file
+tspec plugin:install @tspec/http --config ./custom-config.json
+
+# JSON output for scripting
+tspec plugin:install @tspec/http --output json
+```
+
+## Installation Process
+
+1. Downloads the plugin package from npm
+2. Installs to the TSpec plugins directory (`~/.tspec/plugins/`)
+3. Adds the plugin to your `tspec.config.json`
+
+## Configuration Update
+
+After installation, the plugin is added to your config:
+
+```json
+{
+  "plugins": [
+    "@tspec/http",
+    "@tspec/web"
+  ]
+}
+```
+
+## Local vs Global Installation
+
+| Location | Config File | Use Case |
+|----------|-------------|----------|
+| Local | `./tspec.config.json` | Project-specific plugins (default) |
+| Global | `~/.tspec/tspec.config.json` | Plugins used across all projects |
+
+## Output Format
+
+### Text Output
+
+```
+Successfully installed @tspec/http
+Added to config: ./tspec.config.json
+```
+
+### JSON Output
+
+```json
+{
+  "plugin": "@tspec/http",
+  "installed": true,
+  "configUpdated": true,
+  "configPath": "./tspec.config.json"
+}
+```
+
+## Exit Codes
+
+| Code | Description |
+|------|-------------|
+| `0` | Success |
+| `1` | Installation failed |
+| `2` | Error (invalid plugin name, network error, etc.) |
+
+## Troubleshooting
+
+### Plugin Not Found
+
+```
+Failed to install @tspec/nonexistent: Package not found
+```
+
+- Verify the package name is correct
+- Check if the package exists on npm
+
+### Permission Denied
+
+```
+Failed to install @tspec/http: EACCES permission denied
+```
+
+- Check write permissions for the plugins directory
+- Try running with appropriate permissions
+
+### Already Installed
+
+```
+Plugin @tspec/http is already installed and configured.
+```
+
+The plugin is already available in your environment.
+
+## Related Commands
+
+- [tspec plugin:list](./tspec-plugin-list.md) - List installed plugins
+- [tspec list](./tspec-list.md) - List supported protocols

--- a/skills/tspec/reference/tspec-plugin-list.md
+++ b/skills/tspec/reference/tspec-plugin-list.md
@@ -1,0 +1,115 @@
+# tspec plugin:list
+
+List all installed TSpec plugins and their status. Plugins extend TSpec with custom protocols, assertions, and lifecycle actions.
+
+## CLI Command
+
+### Usage
+
+```bash
+tspec plugin:list [options]
+tspec plugins [options]    # alias
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `json`, `text` (default: `text`) |
+| `-v, --verbose` | Show detailed plugin information (author, homepage) |
+| `--health` | Run health checks on all plugins |
+| `-c, --config <path>` | Path to tspec.config.json |
+
+### CLI Examples
+
+```bash
+# List all installed plugins
+tspec plugin:list
+
+# Use the alias
+tspec plugins
+
+# Show detailed information
+tspec plugin:list -v
+
+# Run health checks
+tspec plugin:list --health
+
+# JSON output
+tspec plugin:list --output json
+```
+
+## Output Format
+
+### Text Output
+
+```
+TSpec Plugins
+
+Config:
+  Local:  ./tspec.config.json
+  Global: ~/.tspec/tspec.config.json
+  Plugins dir: ~/.tspec/plugins
+
+@tspec/http v1.0.0
+  Protocols: http, https
+
+@tspec/web v1.0.0
+  Protocols: web, browser
+
+Supported Protocols: http, https, web, browser
+```
+
+### JSON Output
+
+```json
+{
+  "plugins": [
+    {
+      "name": "@tspec/http",
+      "version": "1.0.0",
+      "description": "HTTP protocol support for TSpec",
+      "protocols": ["http", "https"],
+      "author": "BoolesAI",
+      "homepage": "https://github.com/boolesai/tspec"
+    }
+  ],
+  "protocols": ["http", "https", "grpc", "websocket"],
+  "configPath": "./tspec.config.json",
+  "configSources": {
+    "local": "./tspec.config.json",
+    "global": "~/.tspec/tspec.config.json"
+  },
+  "pluginsDir": "~/.tspec/plugins"
+}
+```
+
+## Health Checks
+
+Use `--health` to verify that all plugins are functioning correctly:
+
+```bash
+tspec plugin:list --health
+```
+
+Output includes health status for each plugin:
+
+```
+Health Check
+
+@tspec/http: ✓ Healthy
+@tspec/web: ✗ Unhealthy
+  Connection timeout
+```
+
+## Exit Codes
+
+| Code | Description |
+|------|-------------|
+| `0` | Success |
+| `2` | Error (invalid config, etc.) |
+
+## Related Commands
+
+- [tspec plugin:install](./tspec-plugin-install.md) - Install a plugin
+- [tspec list](./tspec-list.md) - List supported protocols

--- a/skills/tspec/reference/tspec-run.md
+++ b/skills/tspec/reference/tspec-run.md
@@ -68,6 +68,7 @@ tspec run <files...> [options]
 | `-q, --quiet` | Only output summary |
 | `--fail-fast` | Stop on first failure |
 | `--config <path>` | Path to tspec.config.json |
+| `--no-auto-install` | Skip automatic plugin installation |
 | `--no-proxy` | Disable proxy for this execution |
 | `--proxy-url <url>` | Override proxy URL for this execution |
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tspec",
   "displayName": "Testing Spec",
   "description": "Language support and test runner for TSpec test specification files",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "publisher": "boolesai",
   "icon": "logo.png",
   "repository": {

--- a/vscode-extension/src/providers/completionProvider.ts
+++ b/vscode-extension/src/providers/completionProvider.ts
@@ -12,6 +12,7 @@ import {
   DATA_FIELDS,
   LIFECYCLE_FIELDS,
   LIFECYCLE_ACTION_FIELDS,
+  PROXY_SERVER_FIELDS,
   VARIABLE_FUNCTIONS,
   createFieldCompletions,
   createEnumCompletions,
@@ -80,6 +81,9 @@ export class TSpecCompletionProvider implements vscode.CompletionItemProvider {
       case 'lifecycle-action':
         return createFieldCompletions(LIFECYCLE_ACTION_FIELDS);
       
+      case 'proxy-server':
+        return createFieldCompletions(PROXY_SERVER_FIELDS);
+      
       case 'body':
         return [
           createCompletionItem('json', vscode.CompletionItemKind.Property, 'JSON body', 'JSON request body', new vscode.SnippetString('json:\n  $0')),
@@ -127,6 +131,11 @@ export class TSpecCompletionProvider implements vscode.CompletionItemProvider {
     // Data format
     if (key === 'format' && contextType === 'data') {
       return createEnumCompletions(['csv', 'json', 'yaml']);
+    }
+    
+    // Proxy server enabled field
+    if (key === 'enabled' && contextType === 'proxy-server') {
+      return createEnumCompletions(['true', 'false']);
     }
     
     return [];

--- a/vscode-extension/src/utils/schemaData.ts
+++ b/vscode-extension/src/utils/schemaData.ts
@@ -18,6 +18,7 @@ export const TOP_LEVEL_FIELDS: SchemaField[] = [
   { key: 'data', required: false, type: 'object', description: 'Data-driven testing configuration' },
   { key: 'extends', required: false, type: 'string', description: 'Template file to extend' },
   { key: 'lifecycle', required: false, type: 'object', description: 'Setup and teardown hooks with scope control' },
+  { key: 'proxy_server', required: false, type: 'object', description: 'Override proxy server configuration for this test' },
   { key: 'http', required: false, type: 'object', description: 'HTTP request configuration' },
   { key: 'grpc', required: false, type: 'object', description: 'gRPC request configuration' },
   { key: 'graphql', required: false, type: 'object', description: 'GraphQL request configuration' },
@@ -107,6 +108,14 @@ export const OUTPUT_CONFIG_FIELDS: SchemaField[] = [
   { key: 'notifications', required: false, type: 'array', description: 'Notification configuration' },
 ];
 
+export const PROXY_SERVER_FIELDS: SchemaField[] = [
+  { key: 'url', required: false, type: 'string', description: 'Proxy server URL (http or https)' },
+  { key: 'timeout', required: false, type: 'number', description: 'Request timeout in milliseconds (default: 30000)' },
+  { key: 'headers', required: false, type: 'object', description: 'Custom HTTP headers (supports ${ENV_VAR} expansion)' },
+  { key: 'enabled', required: false, type: 'boolean', description: 'Enable/disable proxy (default: true)' },
+  { key: 'operations', required: false, type: 'array', description: 'Operations to proxy: run, validate, parse' },
+];
+
 // Suite-specific schema definitions
 export const SUITE_TOP_LEVEL_FIELDS: SchemaField[] = [
   { key: 'suite', required: true, type: 'object', description: 'Suite definition block' },
@@ -125,6 +134,7 @@ export const SUITE_FIELDS: SchemaField[] = [
   { key: 'before_each', required: false, type: 'array', description: 'Hooks to run before each test' },
   { key: 'after_each', required: false, type: 'array', description: 'Hooks to run after each test' },
   { key: 'execution', required: false, type: 'object', description: 'Execution configuration' },
+  { key: 'proxy_server', required: false, type: 'object', description: 'Override proxy server configuration for this suite' },
   { key: 'tests', required: false, type: 'array', description: 'Test file references' },
   { key: 'suites', required: false, type: 'array', description: 'Nested suite references' },
 ];

--- a/vscode-extension/src/utils/yamlHelper.ts
+++ b/vscode-extension/src/utils/yamlHelper.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 export interface YamlContext {
-  type: 'top-level' | 'metadata' | 'http' | 'grpc' | 'graphql' | 'websocket' | 'environment' | 'assertions' | 'assertion-item' | 'data' | 'lifecycle' | 'lifecycle-action' | 'variables' | 'body' | 'unknown';
+  type: 'top-level' | 'metadata' | 'http' | 'grpc' | 'graphql' | 'websocket' | 'environment' | 'assertions' | 'assertion-item' | 'data' | 'lifecycle' | 'lifecycle-action' | 'variables' | 'body' | 'proxy-server' | 'unknown';
   keyPath: string[];
   isValuePosition: boolean;
   currentKey?: string;
@@ -122,6 +122,7 @@ export class YamlHelper {
         }
         return 'lifecycle';
       case 'variables': return 'variables';
+      case 'proxy_server': return 'proxy-server';
       default: return 'unknown';
     }
   }

--- a/vscode-extension/syntaxes/tspec.tmLanguage.json
+++ b/vscode-extension/syntaxes/tspec.tmLanguage.json
@@ -6,6 +6,7 @@
     { "include": "#comments" },
     { "include": "#variable-interpolation" },
     { "include": "#top-level-keys" },
+    { "include": "#proxy-server-keys" },
     { "include": "#protocol-blocks" },
     { "include": "#metadata-keys" },
     { "include": "#related-code-values" },
@@ -32,9 +33,20 @@
     "top-level-keys": {
       "patterns": [
         {
-          "match": "^(version|description|metadata|environment|variables|data|extends|lifecycle|assertions)(:)",
+          "match": "^(version|description|protocol|metadata|environment|variables|data|extends|lifecycle|proxy_server|assertions)(:)",
           "captures": {
             "1": { "name": "keyword.control.tspec" },
+            "2": { "name": "punctuation.separator.key-value.tspec" }
+          }
+        }
+      ]
+    },
+    "proxy-server-keys": {
+      "patterns": [
+        {
+          "match": "^\\s+(url|timeout|headers|enabled|operations)(:)",
+          "captures": {
+            "1": { "name": "variable.other.proxy-server.tspec" },
             "2": { "name": "punctuation.separator.key-value.tspec" }
           }
         }

--- a/vscode-extension/syntaxes/tsuite.tmLanguage.json
+++ b/vscode-extension/syntaxes/tsuite.tmLanguage.json
@@ -43,7 +43,7 @@
     "suite-keys": {
       "patterns": [
         {
-          "match": "^\\s+(name|description|version|extends|depends_on|metadata|environment|variables|lifecycle|before_each|after_each|execution|tests|suites)(:)",
+          "match": "^\\s+(name|description|version|extends|depends_on|metadata|environment|variables|lifecycle|before_each|after_each|execution|proxy_server|tests|suites)(:)",
           "captures": {
             "1": { "name": "keyword.control.suite-property.tsuite" },
             "2": { "name": "punctuation.separator.key-value.tsuite" }


### PR DESCRIPTION
…ite override

- Introduced `proxy_server` field in `.tcase` and `.tsuite` files for test-level and suite-level proxy override
- Supported full `ProxyConfig` including `url`, `timeout`, `headers`, `enabled`, and `operations`
- Implemented precedence: DSL-level `proxy_server` config overrides CLI flags and global/local config files
- Added schema validation for proxy server configuration fields
- Enabled disabling proxy per test or suite with `enabled: false`
- Merged headers from DSL-level and global config with DSL taking precedence
- Updated changelog, documentation, and added detailed proxy configuration examples
- Extended VS Code extension with auto-completion, syntax highlighting, and IntelliSense support for `proxy_server`
- Added new MCP skill commands for plugin management and MCP server integration
- Fixed CLI documentation by adding missing flags and sidebar links for proxy server docs